### PR TITLE
Fix SDKS folder empty check

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,22 +31,22 @@ runs:
         if [ ! -d "${{ github.workspace }}/${{ inputs.theos-dir }}" ]; then
           git clone ${{ inputs.theos-src }} ${{ github.workspace }}/${{ inputs.theos-dir }} --recursive
           echo "Theos successfully obtained!"
-        else 
+        else
           echo "Theos already cached, skipping..."
         fi
 
     - name: get sdks
       shell: bash
       run: |
-        if [ ! -d "${{ github.workspace }}/${{ inputs.theos-dir }}/sdks" ]; then
+        if [[ "$(ls ${{ github.workspace }}/${{ inputs.theos-dir }}/sdks)" ]]; then
+          echo "Theos SDKs already cached, skipping..."
+        else
           cd ${{ github.workspace }}/${{ inputs.theos-dir }}/sdks
           curl -sLO ${{ inputs.theos-sdks }}/archive/master.zip
           TMP=$(mktemp -d)
           7z x master.zip -o$TMP
           mv $TMP/*-master/*.sdk $THEOS/sdks
           rm -r master.zip $TMP
-        else
-          echo "Theos SDKs already cached, skipping..."
         fi
 
 branding:


### PR DESCRIPTION
Hey! thanks a lot for this action, it is very useful. I really like how the cache keys for the theos and sdk repos are setup.

I stumbled upon one section however, specifically that `if` check:

https://github.com/Randomblock1/theos-action/blob/2511d6e5863e29f914d02df19d221df10630a4e7/action.yml#L38-L50

Using `-d` works for the `theos` directory, because if it is not cached the directory is simply not present. It does not however work for the `theos/sdks` directory, because that is always present once theos is cloned. That is because of the https://github.com/theos/theos/blob/master/sdks/.keep file. The directory is thus always present, so the action thinks the skds were cached when they actually weren't.

To fix this i propose to use a simple `ls` check, which ignores hidden files by default so it checks if there are any folders in `theos/sdks` but it does not register the `.keep` file. Of course, any other mechanism that would do a proper check could also be used.